### PR TITLE
Fix makefile, remove duplicate definition

### DIFF
--- a/bgp.cpp
+++ b/bgp.cpp
@@ -29,6 +29,16 @@ vector<int> bgp::get_neibor() const
     return neibor_list;
 }
 
+unsigned int bgp::get_pref() const
+{
+    return preference;
+}
+
+void bgp::set_perf(unsigned int perf)
+{
+    preference = perf;
+}
+
 void bgp::print() const
 {
     cout << index <<" "<< neibor_size << "\n";

--- a/bgp.h
+++ b/bgp.h
@@ -14,6 +14,8 @@ public:
     bgp();
     bgp(int i, vector<int> nlist);
     int get_index() const;
+    unsigned int get_pref() const;
+    void set_perf (unsigned int perf);
     int get_size() const;
     vector<int> get_neibor() const;
     void print() const;
@@ -23,6 +25,7 @@ public:
 private:
     int index;
     int neibor_size;
+    unsigned int preference;
     vector<int> neibor_list;
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -62,18 +62,6 @@ vector<string>& filter(vector<string>& data)
     return data;
 }
 
-vector<string>& filter(vector<string>& data)
-{
-   for(int i=0;i<data.size();i++)
-    {
-       if(data[i].find('[') !=string::npos)
-            data.erase(data.begin()+i,data.end());
-    }
-
-    data.erase(unique(data.begin(),data.end()),data.end());
-    return data;
-}
-
 vector<int> convert (vector<string> data)
 {
     vector<int> temp;

--- a/makefile
+++ b/makefile
@@ -1,11 +1,11 @@
 proj1.x: main.o bgp.o
-        g++ -o proj1.x main.o bgp.o
+	g++ -o proj1.x main.o bgp.o
 
 main.o: main.cpp bgp.h
-        g++ -c main.cpp
+	g++ -c main.cpp
 
 bgp.o: bgp.cpp bgp.h
-        g++ -c bgp.cpp
+	g++ -c bgp.cpp
 
 clean:
-        rm *.o proj1.x
+	rm *.o proj1.x


### PR DESCRIPTION
Replaced Spaces with Tabs in Makefile:
Converted all spaces to tab characters to comply with standard Makefile formatting requirements.
Removed Duplicate Definition of filter():
Eliminated the redundant definition of the filter() function to improve code clarity and maintainability.
